### PR TITLE
Add a local server to test store_data

### DIFF
--- a/tools/local_server.py
+++ b/tools/local_server.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+from wsgiref.simple_server import WSGIRequestHandler, make_server
+
+
+# Import the WSGI application and determine the template dir
+server_dir = Path(__file__).parents[1] / "server"
+template_dir = Path(__file__).parents[1] / "templates"
+
+sys.path.insert(0, str(server_dir))
+
+import store_data
+
+
+class SFB1451RequestHandler(WSGIRequestHandler):
+    def get_environ(self):
+        wsgi_environment = WSGIRequestHandler.get_environ(self)
+        wsgi_environment.update({
+            "de.inm7.sfb1451.entry.dataset_root": "/tmp/sfb-test",
+            "de.inm7.sfb1451.entry.home": "/tmp/sfb-test-home",
+            "de.inm7.sfb1451.entry.templates": str(template_dir)
+        })
+        return wsgi_environment
+
+
+with make_server('', 8000, store_data.application, handler_class=SFB1451RequestHandler) as httpd:
+    print("Serving HTTP on port 8000...")
+    httpd.serve_forever()


### PR DESCRIPTION
This PR adds a local server that can execute `store_data.application` based on an HTTP-request, ususally from a browser.

The server is started with (if `cwd` is the root of the project):
```shell
python tools/local_server.py
```
It serves at `http://local_host:8000`. By copying `entry.html` to `entry_local.html` and changing the`formaction` attribute in `entry_local.html` to `http://localhost:8000/store_data`, you can use your browser on `entry_local.html` to test the behavior of `store_data.application`.

This PR is geared toward a unixy system, i.e. it assumes that a writable `/tmp`-directory exists. It also assumes:

1.  `datalad` is in your path
2.  `/tmp/sfb-test` exists and is a datalad dataset
3. `/tmp/sfb-test-home` exists and is a writeable directory
