### PR TITLE
Local save tweak

### DIFF
--- a/entry.html
+++ b/entry.html
@@ -2341,7 +2341,7 @@
 
 
 <script>
-    const submitButtonToggler = {
+    const submitButtonUpdater = {
         // a global object to track whether the save button can be enabled
         // and to toggle its state when needed
         // we require data to be validated and only allow submitting after
@@ -2356,10 +2356,10 @@
                 submitButton.setAttribute("disabled", "");
             }
         },
-        toggle: function (property, value) {
+        setAndUpdate: function (property, value) {
             console.assert(
                 typeof value === "boolean",
-                "Toggle called with non-boolean value"
+                "setAndUpdate called with non-boolean value"
             );
             console.assert(
                 this.hasOwnProperty(property),
@@ -2856,14 +2856,13 @@
     function updateFingerPrint() {
         let fingerPrintElement = document.getElementById("finger-print");
         let entryForm = document.getElementById("entry-form");
-        // let submitButton = document.getElementById("submit-button");  delegated to submitButtonToggler
         let hashedStringElement = document.getElementById("hashed-string");
         let hashValueElement = document.getElementById("hash-value");
         let signatureDataElement = document.getElementById("signature-data");
 
         if (validateForm(entryForm) === false) {
             fingerPrintElement.innerHTML = "Fingerabruck nicht verfügbar, da Eingaben ungültig sind.";
-            submitButtonToggler.toggle("dataValid", false)
+            submitButtonUpdater.setAndUpdate("dataValid", false)
             signatureDataElement.setAttribute("disabled", "");
         } else {
             const contentString = getContentString();
@@ -2873,11 +2872,11 @@
                 console.log(hashHex);
                 fingerPrintElement.innerHTML = hashHex;
                 hashValueElement.value = hashHex;
-                submitButtonToggler.toggle("dataValid", true)
+                submitButtonUpdater.setAndUpdate("dataValid", true)
             }).catch(err => {
                 console.log(err);
                 fingerPrintElement.innerHTML = "Fingerabruck nicht verfügbar: " + err;
-                submitButtonToggler.toggle("dataValid", false)
+                submitButtonUpdater.setAndUpdate("dataValid", false)
             });
         }
     }
@@ -3156,7 +3155,7 @@
         a.remove();
 
         // allow submit button to be enabled
-        submitButtonToggler.toggle("dataSaved", true);
+        submitButtonUpdater.setAndUpdate("dataSaved", true);
         return false;
     };
 </script>

--- a/entry.html
+++ b/entry.html
@@ -2341,6 +2341,38 @@
 
 
 <script>
+    const submitButtonToggler = {
+        // a global object to track whether the save button can be enabled
+        // and to toggle its state when needed
+        // we require data to be validated and only allow submitting after
+        // the local save has been done
+        dataValid: false,
+        dataSaved: false,
+        update: function () {
+            let submitButton = document.getElementById("submit-button");
+            if (this.dataValid && this.dataSaved) {
+                submitButton.removeAttribute("disabled");
+            } else {
+                submitButton.setAttribute("disabled", "");
+            }
+        },
+        toggle: function (property, value) {
+            console.assert(
+                typeof value === "boolean",
+                "Toggle called with non-boolean value"
+            );
+            console.assert(
+                this.hasOwnProperty(property),
+                "Unknown property: " + property
+            );
+            this[property] = value;
+            this.update();
+        },
+    };
+</script>
+
+
+<script>
     function getContentOfElementNamed(name) {
         const elementArray = document.getElementsByName(name);
         if (elementArray.length === 1)
@@ -2824,14 +2856,14 @@
     function updateFingerPrint() {
         let fingerPrintElement = document.getElementById("finger-print");
         let entryForm = document.getElementById("entry-form");
-        let submitButton = document.getElementById("submit-button");
+        // let submitButton = document.getElementById("submit-button");  delegated to submitButtonToggler
         let hashedStringElement = document.getElementById("hashed-string");
         let hashValueElement = document.getElementById("hash-value");
         let signatureDataElement = document.getElementById("signature-data");
 
         if (validateForm(entryForm) === false) {
             fingerPrintElement.innerHTML = "Fingerabruck nicht verfügbar, da Eingaben ungültig sind.";
-            submitButton.setAttribute("disabled", "");
+            submitButtonToggler.toggle("dataValid", false)
             signatureDataElement.setAttribute("disabled", "");
         } else {
             const contentString = getContentString();
@@ -2841,11 +2873,11 @@
                 console.log(hashHex);
                 fingerPrintElement.innerHTML = hashHex;
                 hashValueElement.value = hashHex;
-                submitButton.removeAttribute("disabled");
+                submitButtonToggler.toggle("dataValid", true)
             }).catch(err => {
                 console.log(err);
                 fingerPrintElement.innerHTML = "Fingerabruck nicht verfügbar: " + err;
-                submitButton.setAttribute("disabled", "");
+                submitButtonToggler.toggle("dataValid", false)
             });
         }
     }
@@ -3122,6 +3154,9 @@
         a.setAttribute("href", URL.createObjectURL(bb));
         a.click();
         a.remove();
+
+        // allow submit button to be enabled
+        submitButtonToggler.toggle("dataSaved", true);
         return false;
     };
 </script>

--- a/entry.html
+++ b/entry.html
@@ -2264,13 +2264,15 @@
 
 
         <div class="row pt-5">
-            <button class="btn btn-primary btn-lg btn-block" type="submit" id="submit-button" formaction="https://sfb1451.inm7.de/store-data" formmethod="post" disabled>Daten speichern</button>
-        </div>
-
-        <div class="row pt-5">
             <!-- Eine lokale Kopie der Formulardaten speichern -->
             <button class="btn btn-primary btn-lg btn-block" type="button" id="local-save-button">Daten lokal speichern</button>
         </div>
+
+
+        <div class="row pt-5">
+            <button class="btn btn-primary btn-lg btn-block" type="submit" id="submit-button" formaction="https://sfb1451.inm7.de/store-data" formmethod="post" disabled>Daten speichern</button>
+        </div>
+
 
         <div class="row pt-5">
             <!-- Eine lokale Kopie der Formulardaten laden -->


### PR DESCRIPTION
This PR closes #29 with the following changes:

- Save buttons at the end were reordered (now: 1 - Daten lokal speichern, 2 - Daten speichern 3 - Lokale Daten laden).

- The submit button (Daten Speichern) is now enabled only after the local save has been used. This makes local save essentially required (though there are loopholes). From the code point of view, the state of the submit button (enabled/disabled) is now tracked by a global variable pointing to an object literal, which has a a method to update. I'm not sure if that's the best way of doing so, and if you have better ones I'd be happy to rework it. The goal is to make it harder to "forget" local saving and send the data straight away, thus exiting the form (i just lacked imagination to do something other than what was literally requested).