### PR TITLE
Push plain dataset to encrypted ria store after modification

### DIFF
--- a/.github/workflows/run-server-tests.yml
+++ b/.github/workflows/run-server-tests.yml
@@ -27,7 +27,11 @@ jobs:
           which git-annex
           echo which datalad
           which datalad
+          datalad --version
           if [ -f requirements-devel.txt ]; then pip install -r requirements-devel.txt; fi
+          pip install datalad --upgrade
+          which datalad
+          datalad --version
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/server/store_data.py
+++ b/server/store_data.py
@@ -277,6 +277,20 @@ def add_file_to_dataset(dataset_root: Path, file: Path, home: Path):
             "HOME": str(home)
         })
 
+    subprocess.run(
+        [
+            "datalad",
+            "push",
+            "-d", str(dataset_root),
+            "--to", "entrystore",
+            str(file)
+        ],
+        check=True,
+        env={
+            **os.environ,
+            "HOME": str(home)
+        })
+
     return subprocess.run(
         [
             "git",

--- a/server/tests/test_store_data.py
+++ b/server/tests/test_store_data.py
@@ -103,8 +103,20 @@ class TestStoreData(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
 
             dataset_path = Path(temp_dir) / "dataset"
-            subprocess.run(["datalad", "create", "-c", "text2git", str(dataset_path)])
-            subprocess.run(["datalad", "no-annex", "-d", str(dataset_path)])
+            subprocess.run(
+                ["datalad", "create", "--no-annex", str(dataset_path)],
+                check=True
+            )
+
+            sibling_path = Path(temp_dir) / "entrystore"
+            sibling_path.mkdir()
+            subprocess.run(
+                [
+                    "datalad", "create-sibling", "-d", str(dataset_path), "-s",
+                    "entrystore", str(sibling_path)
+                ],
+                check=True
+            )
 
             with patch("time.time") as time_mock:
                 time_mock.return_value = 0.0
@@ -120,8 +132,11 @@ class TestStoreData(unittest.TestCase):
 
             expected_path = dataset_path / "input/2.2/0.0.json"
             with expected_path.open() as f:
-                json_object = json.load(f)
-        print(json_object)
+                json_object_1 = json.load(f)
+            expected_sibling_path = sibling_path / "input/2.2/0.0.json"
+            with expected_sibling_path.open() as f:
+                json_object_2 = json.load(f)
+            assert json_object_1 == json_object_2
 
     def test_get_int(self):
         self.assertEqual(get_int_value(".0"), 0)


### PR DESCRIPTION
This fixes issue #31 

After an entry has been saved into the plaintext entry dataset, the plaintext entry dataset is pushed to the encrypted entry dataset.

This is the first step of the encryption at rest implementation. The next step would be to drop the newly saved entry from the plaintext dataset (issue #33)

