### PR TITLE
Update max recognized error time in go/no-go

### DIFF
--- a/entry.html
+++ b/entry.html
@@ -1148,10 +1148,10 @@
                 </div>
                 <div class="col-lg-6 entry-value">
                     <div class="input-group has-validation">
-                        <input type="number" class="form-control" id="go-nogo-recognized-error-time" name="go-nogo-recognized-error-time" min="50.0" max="800.0" step="any" placeholder="50.0 - 800.0" required disabled>
+                        <input type="number" class="form-control" id="go-nogo-recognized-error-time" name="go-nogo-recognized-error-time" min="50.0" max="1000.0" step="any" placeholder="50.0 - 1000.0" required disabled>
                         <div class="input-group-text">ms</div>
                         <div class="invalid-feedback field-validity">
-                            Zahlenwert zwischen 50.0 und 800.0 erwartet.
+                            Zahlenwert zwischen 50.0 und 1000.0 erwartet.
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Upon request, the maximum allowed reaction time for recognized error in the go/no-go task (Reaktionszeit erkannte Fehler) was increased from 800 to 1000 ms.